### PR TITLE
Restructure docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .php_cs.cache
 nbproject
 composer.lock
+docs/html

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,9 +1,10 @@
 {
-  "title": "Prooph Standard Projections for Event-Store",
+  "title": "Standard Projections",
   "content": [
-    {"intro": "../README.md"},
     {"overview": "projections.md"}
   ],
+  "tocDepth": 1,
+  "numbering": false,
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"
 }

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,8 +1,19 @@
-# Prooph Standard Projections for Event-Store
+# Overview
 
 The standard projections are some kind of event-indexing, so you can retrieve events from
 all streams at once (`AllStreamProjectionRunner`), by category (`CategoryStreamProjectionRunner`)
 or by message name (`MessageNameStreamProjectionRunner`).
+
+## Installation
+
+```bash
+composer require prooph/standard-projections
+```
+
+## Requirements
+
+- PHP >= 7.1
+- Prooph EventStore v7
 
 ## AllStreamProjectionRunner
 


### PR DESCRIPTION
According to https://github.com/prooph/proophessor/issues/38#issuecomment-336200542

- shorter headlines
- introduction instead of using entire README (better overview while browsing through the docs)